### PR TITLE
If you have a empty element followed by a text node, it throws an exception trying to append the ellipsis to the empty node.

### DIFF
--- a/src/jquery.autoellipsis.js
+++ b/src/jquery.autoellipsis.js
@@ -194,7 +194,7 @@
                         // If ellipsis was succesfully applied, remove any remaining empty last elements and append the
                         // ellipsis characters.
                         if (ellipsisApplied) {
-                            removeLastEmptyElements(selectedElement);
+                            while(removeLastEmptyElements(selectedElement)) {}
 
                             // If the selected element is not empty, append the ellipsis characters.
                             if (selectedElement.contents().length) {


### PR DESCRIPTION
I had a <br /> followed by text.  The text got pruned away, and then the call to removeLastEmptyElements removed the empty text node.  But then it tried to concatenate the ellipsis onto the <br />.

I simply put the removeLastEmptyElements in a loop to clear all the empty elements at the end.
